### PR TITLE
Leave error archive

### DIFF
--- a/hommod/controllers/model.py
+++ b/hommod/controllers/model.py
@@ -511,8 +511,11 @@ class Modeler:
         output_yob_path = os.path.join(work_dir_path, 'target.yob')
         error_path = os.path.join(work_dir_path, 'errorexit.txt')
         error_scene_path = os.path.join(work_dir_path, 'errorexit.sce')
+        before_scene_path =  os.path.join(work_dir_path, 'beforemodel.sce')
         try:
             context.yasara.CD(work_dir_path)
+
+            context.yasara.SaveSce(before_scene_path)
 
             self._write_model_alignment_fasta(context, chain_alignments, align_fasta_path)
 

--- a/hommod/controllers/storage.py
+++ b/hommod/controllers/storage.py
@@ -92,6 +92,18 @@ class ModelStorage:
 
         return self.get_tar_path_from_name(name)
 
+    def get_error_tar_path_from_name(self, name):
+        if self.model_dir is None:
+            raise InitError("model directory is not set")
+
+        return os.path.join(self.model_dir, name + '_error.tgz')
+
+    def get_error_tar_path(self, target_sequence, target_species_id, main_domain_alignment, template_id):
+        name = self.get_model_name(target_sequence, target_species_id,
+                                   main_domain_alignment, template_id)
+
+        return self.get_error_tar_path_from_name(name)
+
     def get_model_lock(self, main_target_sequence, target_species_id,
                        main_domain_alignment, template_id):
         if self.model_dir is None:

--- a/hommod/controllers/yasara.py
+++ b/hommod/controllers/yasara.py
@@ -188,3 +188,7 @@ class YasaraContext:
         command = 'SavePDB %s, Filename=%s' % (self._yasara_module.selstr(selection),
                                                self._yasara_module.cstr(filename))
         self._run(command)
+
+    def SaveSce(self, filename):
+        command = 'SaveSce %s' % filename
+        self._run(command)

--- a/hommod/services/uniprot.py
+++ b/hommod/services/uniprot.py
@@ -19,10 +19,9 @@ class UniprotService:
 
         _log.debug(fasta_url)
 
-        try:
+        r = requests.get(fasta_url)
+        while r.status_code == 500:
             r = requests.get(fasta_url)
-        except requests.exceptions.ConnectTimeout:
-            raise ServiceError("timeout connecting with uniprot")
 
         r.raise_for_status()
 

--- a/tests/integration/controllers/test_model.py
+++ b/tests/integration/controllers/test_model.py
@@ -212,6 +212,9 @@ def test_generate_error_archive():
         def Wait(self, s):
             pass
 
+        def SaveSce(self, filename):
+            pass
+
     class FakeContext:
         def __init__(self):
             self.target_species_id = 'HUMAN'

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -1,8 +1,10 @@
 import tarfile
 import os
+from glob import glob
 import shutil
 import tempfile
 
+from mock import patch
 from nose.tools import with_setup, ok_
 from celery import Celery
 
@@ -189,4 +191,5 @@ def test_create_model_5GJV():
     except ModelRunError as e:
         message = str(e)
         ok_('error 39' in message)
+
 


### PR DESCRIPTION
When yasara shows an error that should be reported, generate an error archive, containing the input data needed to reproduce the error.